### PR TITLE
Support using busybox instead of bash on Linux

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -2,6 +2,7 @@ almalinux
 archlinux
 clangarm
 cygdrive
+Ceuo
 doas
 fastestmirror
 LASTEXITCODE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,17 +129,17 @@ jobs:
           - opensuse/leap:latest # glibc 2.38 (as of leap 15.6)
           - opensuse/tumbleweed:latest # glibc 2.39 (as of 2024-07-19)
           - archlinux:latest # glibc 2.39 (as of 2024-07-19)
-          - alpine:3.2 # musl 1.1.11
-          - alpine:3.14 # musl 1.2.2
-          - alpine:3.15 # musl 1.2.2
-          - alpine:3.16 # musl 1.2.3
-          - alpine:3.17 # musl 1.2.3
-          - alpine:3.18 # musl 1.2.4
-          - alpine:3.19 # musl 1.2.4
-          - alpine:3.20 # musl 1.2.5
-          - alpine:3.21 # musl 1.2.5
-          - alpine:3.22 # musl 1.2.5
-          - alpine:3.23 # musl 1.2.5
+          - alpine:3.2 # musl 1.1.11, busybox 1.23.2
+          - alpine:3.14 # musl 1.2.2, busybox 1.33.1
+          - alpine:3.15 # musl 1.2.2, busybox 1.34.1
+          - alpine:3.16 # musl 1.2.3, busybox 1.35.0
+          - alpine:3.17 # musl 1.2.3, busybox 1.35.0
+          - alpine:3.18 # musl 1.2.4, busybox 1.36.1
+          - alpine:3.19 # musl 1.2.4, busybox 1.36.1
+          - alpine:3.20 # musl 1.2.5, busybox 1.36.1
+          - alpine:3.21 # musl 1.2.5, busybox 1.37.0
+          - alpine:3.22 # musl 1.2.5, busybox 1.37.0
+          - alpine:3.23 # musl 1.2.5, busybox 1.37.0
           # TODO: opkg doesn't work since https://github.com/openwrt/openwrt/issues/16935#issuecomment-2472747379
           # but apk is not installed in the 23.05/24.10 container: "apk: not found"
           # - openwrt/rootfs:x86-64-openwrt-24.10 # musl 1.2.5
@@ -187,4 +187,6 @@ jobs:
       # TODO: use the current branch instead of @main
       - uses: taiki-e/checkout-action@main # zizmor: ignore[unpinned-uses] # For test.
       - run: git ls-files
+        shell: sh
       - run: test -f ./tools/tidy.sh
+        shell: sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev
+      - busybox
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -73,7 +74,7 @@ jobs:
           printf '%s\n' 'C:\tools\cygwin\usr\bin' >>"${GITHUB_PATH}"
         if: matrix.bash == 'cygwin'
       # TODO: use the current branch instead of @main
-      - uses: taiki-e/checkout-action@main # zizmor: ignore[unpinned-uses] # For test.
+      - uses: taiki-e/checkout-action@busybox # zizmor: ignore[unpinned-uses] # For test.
       - run: git ls-files
       - run: test -f ./tools/tidy.sh
       - run: ./tools/tidy.sh
@@ -185,7 +186,7 @@ jobs:
           CONTAINER: ${{ matrix.container }}
         if: startsWith(matrix.container, 'centos')
       # TODO: use the current branch instead of @main
-      - uses: taiki-e/checkout-action@main # zizmor: ignore[unpinned-uses] # For test.
+      - uses: taiki-e/checkout-action@busybox # zizmor: ignore[unpinned-uses] # For test.
       - run: git ls-files
         shell: sh
       - run: test -f ./tools/tidy.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
   Unlike actions/checkout (which writes credentials to disk as plaintext even when `persist-credentials` is set to `false`, when git is available), this action does not write credentials to disk even if `token` input option is set.
 
+- This action no longer needs `bash` on Linux if `busybox` is available, e.g., Alpine container. ([#13](https://github.com/taiki-e/checkout-action/pull/13))
+
+  Compatibility Note: Subsequent steps that have relied on this action installing bash for its setup may no longer work as a result. Such workflows can be fixed by adding the following steps (in the case of Alpine).
+
+  ```yaml
+  - run: apk --no-cache add bash
+  ```
+
+  Note that this action is not an action for installing those tools, so changing what this action installs for its setup is considered an implementation detail, so this is not considered a major change.
+
 ## [1.4.2] - 2026-04-04
 
 - Implement workaround for [windows-11-arm runner bug](https://github.com/actions/partner-runner-images/issues/169) which may causes issue that the action successfully completes but not checked out.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ On Linux, if any required tools are missing, this action will attempt to install
 
 On other platforms, at least the following tools are required:
 
-- bash 3.2+
+- bash 3.2+ (or busybox on Linux)
 - git 1.8+
 
 Known environments affected by the above version requirements are CentOS 6 (EoL on 2020-11) and Ubuntu 12.04 (EoL on 2017-04) using git 1.7 (see "Install requirements" in [our CI config](https://github.com/taiki-e/checkout-action/blob/HEAD/.github/workflows/ci.yml) for example of workaround).

--- a/action.yml
+++ b/action.yml
@@ -26,34 +26,17 @@ runs:
           exit 1
         fi
         if ! command -v bash >/dev/null; then
-          if "${grep}" -Eq '^ID=alpine' /etc/os-release; then
-            printf '::group::Install packages required for checkout-action (bash)\n'
-            # NB: sync with apk_install in main.sh
-            if command -v sudo >/dev/null; then
-              sudo apk --no-cache add bash
-            elif command -v doas >/dev/null; then
-              doas apk --no-cache add bash
+          if command -v busybox >/dev/null; then
+            if command -v /bin/busybox >/dev/null; then
+              /bin/busybox sh "${GITHUB_ACTION_PATH:?}/main.sh"
             else
-              apk --no-cache add bash
+              printf '::warning::busybox is unavailable at standard location; using %s\n' "$(command -v busybox)"
+              busybox sh "${GITHUB_ACTION_PATH:?}/main.sh"
             fi
-            printf '::endgroup::\n'
-          elif "${grep}" -Eq '^ID_LIKE=.*openwrt' /etc/os-release; then
-            printf '::group::Install packages required for checkout-action (bash)\n'
-            # NB: sync with opkg_install in main.sh
-            if command -v sudo >/dev/null; then
-              sudo mkdir -p /var/lock
-              sudo opkg update
-              sudo opkg install bash
-            else
-              mkdir -p /var/lock
-              opkg update
-              opkg install bash
-            fi
-            printf '::endgroup::\n'
-          else
-            printf '::error::checkout-action requires bash\n'
-            exit 1
+            exit
           fi
+          printf '::error::checkout-action requires bash or busybox\n'
+          exit 1
         fi
         if command -v /bin/bash >/dev/null; then
           /bin/bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/main.sh"

--- a/main.sh
+++ b/main.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-set -CeEuo pipefail
+# Do not set -E as busybox 3.15 and older don't support it.
+set -Ceuo pipefail
 IFS=$'\n\t'
 
 g() {


### PR DESCRIPTION
Changes:
- This action no longer needs `bash` on Linux if `busybox` is available, e.g., Alpine container.

  Compatibility Note: Subsequent steps that have relied on this action installing bash for its setup may no longer work as a result. Such workflows can be fixed by adding the following steps (in the case of Alpine).

  ```yaml
  - run: apk --no-cache add bash
  ```

  Note that this action is not an action for installing those tools, so changing what this action installs for its setup is considered an implementation detail, so this is not considered a major change.

Closes https://github.com/taiki-e/checkout-action/pull/8
Related: https://github.com/taiki-e/cache-cargo-install-action/pull/16