### PR TITLE
Support checking out private repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support checking out private repository. ([#16](https://github.com/taiki-e/checkout-action/pull/16))
+
+  To use this action in private repositories, explicitly set `token` input option:
+
+  ```yaml
+  - uses: taiki-e/checkout-action@v1
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  ```
+
+  Almost equivalent to:
+
+  ```yaml
+  - uses: actions/checkout@v6
+    with:
+      persist-credentials: false
+  ```
+
+  Unlike actions/checkout (which writes credentials to disk as plaintext even when `persist-credentials` is set to `false`, when git is available), this action does not write credentials to disk even if `token` input option is set.
+
 ## [1.4.2] - 2026-04-04
 
 - Implement workaround for [windows-11-arm runner bug](https://github.com/actions/partner-runner-images/issues/169) which may causes issue that the action successfully completes but not checked out.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,24 @@ The features supported as of v1.0.0 are purely based on my use cases within publ
 - uses: taiki-e/checkout-action@v1
 ```
 
-Almost equivalent to (for public repositories):
+Almost equivalent to:
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    persist-credentials: false
+    token: ''
+```
+
+To use this action in private repositories, explicitly set `token` input option:
+
+```yaml
+- uses: taiki-e/checkout-action@v1
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Almost equivalent to:
 
 ```yaml
 - uses: actions/checkout@v6
@@ -35,6 +52,8 @@ Almost equivalent to (for public repositories):
 As of 2024-03-08, the latest version of [actions/checkout] that uses node20 [doesn't work on CentOS 7](https://github.com/actions/runner/issues/2906).
 
 Also, in `actions/*` actions, each update of the Node.js used increments the major version (it is the correct behavior for compatibility although), so workflows that use it require maintenance on a regular basis. (Unless you have fully automated dependency updates.)
+
+In addition to not using tokens by default, this action does not write credentials to disk even if `token` input option is set, but actions/checkout (as of 6.0.2) [writes credentials to disk as plaintext even when `persist-credentials` is set to `false`, when git is available](https://github.com/taiki-e/checkout-action/pull/16). Therefore, this action is considered more secure than actions/checkout not only by default but also when `persist-credentials` is set to `false`.
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: checkout-action
 description: GitHub Action for checking out a repository. (Simplified actions/checkout alternative that does not depend on Node.js.)
 
+inputs:
+  token:
+    description: GitHub token for checking out a repository.
+    required: false
+
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
 # - Use GITHUB_*/RUNNER_* instead of github.*/runner.* due to https://github.com/actions/runner/issues/2185
@@ -41,6 +46,9 @@ runs:
         fi
         bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/main.sh"
       shell: sh
+      env:
+        # NB: Sync with Windows case.
+        INPUT_TOKEN: ${{ inputs.token }}
       if: runner.os != 'Windows'
     # Use pwsh and retry on bash startup failure to work around windows-11-arm runner bug:
     # https://github.com/actions/partner-runner-images/issues/169
@@ -64,4 +72,7 @@ runs:
         Write-Output "::error::installation failed due to bash startup failure (<https://github.com/actions/partner-runner-images/issues/169>); this maybe resolved by re-running job"
         exit 1
       shell: pwsh
+      env:
+        # NB: Sync with non-Windows case.
+        INPUT_TOKEN: ${{ inputs.token }}
       if: runner.os == 'Windows'

--- a/main.sh
+++ b/main.sh
@@ -95,6 +95,14 @@ sys_install() {
   esac
 }
 
+if [[ $# -gt 0 ]]; then
+  bail "invalid argument '$1'"
+fi
+
+token="${INPUT_TOKEN}"
+# This prevents tokens from being exposed to subprocesses via environment variables.
+unset INPUT_TOKEN
+
 base_distro=''
 case "$(uname -s)" in
   Linux)
@@ -216,6 +224,29 @@ g git init
 g git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
 g git config --local gc.auto 0
+
+if [[ -n "${token}" ]]; then
+  prev_credential_helper=$(git config get --local credential.helper || true)
+  if [[ -n "${prev_credential_helper}" ]]; then
+    bail "credential helper is already set (${prev_credential_helper}); this should not happen in clean checkout"
+  fi
+  protocol="${GITHUB_SERVER_URL%%://*}"
+  hostname="${GITHUB_SERVER_URL#*://}"
+  hostname="${hostname%%/*}"
+  # Sanitize inputs and runner-provided environment variables for here-doc.
+  if [[ "${protocol}" == *$'\n'* ]] || [[ "${hostname}" == *$'\n'* ]] || [[ "${GITHUB_ACTOR}" == *$'\n'* ]] || [[ "${token}" == *$'\n'* ]]; then
+    bail "GITHUB_SERVER_URL and GITHUB_ACTOR and 'token' input option must not contain newline"
+  fi
+  g git config --local credential.helper cache
+  git credential approve <<EOF
+protocol=${protocol}
+host=${hostname}
+username=${GITHUB_ACTOR}
+password=${token}
+EOF
+  # Remove credential helper config on exit.
+  trap -- 'g git credential-cache exit; g git config --local --unset credential.helper || true' EXIT
+fi
 
 if [[ "${GITHUB_REF}" == "refs/heads/"* ]]; then
   branch="${GITHUB_REF#refs/heads/}"


### PR DESCRIPTION
Closes #1 

To use this action in private repositories, explicitly set `token` input option:

```yaml
- uses: taiki-e/checkout-action@v1
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
```

Unlike actions/checkout and https://github.com/taiki-e/checkout-action/issues/1#issuecomment-2210777971 's approach, this PR's  implementation doesn't write credentials to disk.
<details><summary>FYI: actions/checkout@v6.0.2 writes credentials to disk even if preserve-credentials is false (click to show details)</summary>

- getSource calls configureAuth if git exists: https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-source-provider.ts#L133
- configureAuth calls configureToken: https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-auth-helper.ts#L82
- configureToken writes credential to file: https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-auth-helper.ts#L358
- getSource calls removeAuth at the last if persist-credentials is false:  https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-source-provider.ts#L302
- removeAuth calls removeToken: https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-auth-helper.ts#L233
- removeToken removes credential files: https://github.com/actions/checkout/blob/0c366fd6a839edf440554fa01a7085ccba70ac98/src/git-auth-helper.ts#L494

See also https://github.com/orgs/community/discussions/179107#discussioncomment-14906259

</details>